### PR TITLE
Remove extra class attribute from generated embed code

### DIFF
--- a/generators/embeddable-graphic/templates/README.md
+++ b/generators/embeddable-graphic/templates/README.md
@@ -32,7 +32,7 @@ This is an embeddable graphic built using the [`dmninteractives` Yeoman generato
 The below embed code can be pasted into a Serif "code block":
 
 ```html
-<div id="embed-<%= slug %>" class="embed-preview"></div>
+<div id="embed-<%= slug %>"></div>
 
 <script src="//pym.nprapps.org/pym.v1.min.js"></script>
 <script>new pym.Parent('embed-<%= slug %>', '//interactives.dallasnews.com/embeds/<%= year %>/<%= slug %>/', {})</script>


### PR DESCRIPTION
Rounding up bugfixes here before we `npm publish`. For now:
- removes an extra class from the README embed code (8493bdb5f6773d94408fad44a4883d6d9e792f2a)