### PR TITLE
Closes #59. Cache headers, invalidation for CloudFront

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/) from v0.5.0 forward.
 
 ## Unreleased
+### Added
+- Invalidate Cloudfront for published objects during publish (#59)
+
 ### Fixed
 - Also watch SVGs in `src/` and rerun the Nunjucks renderer when they change (#58)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,23 @@ and this project adheres to [Semantic Versioning](http://semver.org/) from v0.5.
 ### Fixed
 - Also watch SVGs in `src/` and rerun the Nunjucks renderer when they change (#58)
 
+## [0.7.6] - 2018-04-30
+### Fixed
+- Bump BrowserSync version in generated apps to close [vulnerability](https://github.com/BrowserSync/browser-sync/issues/1546) in `localtunnel` dependency, which relies on a vulnerable version of `hoek`
+- Bump `octonode` version in this repo to fix a similar dependency on `hoek`
+- Repair CHANGELOG
+
 ## [0.7.5] - 2018-03-01
 ### Changed
-- Changed font weights on embeddables to use LifeBlue's Gotham
+- Updates font weights for new font stack
 
 ## [0.7.4] - 2018-02-26
 ### Changed
-- Change Typography.com account to LifeBlue's
+- Switches typography.com call to DMN house account
+- Pin frontend dependencies (jQuery, etc.) at major version so we get the latest and greatest
+- Include [package-lock.json](package-lock.json) file in VC
 
-## [0.7.3] - 2017-12-27
+## [0.7.3] - 2018-02-14
 ### Fixed
 - Correctly prepends leading `0` in dates in meta.json
 
@@ -220,12 +228,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/) from v0.5.
 ### Added
 - Initial working versions of files.
 
-[Unreleased]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/6aab9f55ec148cbc269083b9326e9d36926881db...HEAD
-[0.7.5]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/fb56abcf7731d6284ed24bd4aa93bfabced809ad...6aab9f55ec148cbc269083b9326e9d36926881db
-[0.7.4]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/338270b3637169712a31751f8e203e76baf2b09c...fb56abcf7731d6284ed24bd4aa93bfabced809ad
-[0.7.3]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/0cd22e4af3f133720612f9aa322555a766af15b4...338270b3637169712a31751f8e203e76baf2b09c
-[0.7.2]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/faaf14fb6e120e84112129eb80efc212f40f6e65...0cd22e4af3f133720612f9aa322555a766af15b4
-[0.7.1]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/v0.7.0...faaf14fb6e120e84112129eb80efc212f40f6e65
+[Unreleased]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/v0.7.6...HEAD
+[0.7.6]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/v0.7.5...v0.7.6
+[0.7.5]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/v0.7.4...v0.7.5
+[0.7.4]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/v0.7.3...v0.7.4
+[0.7.3]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/v0.7.2...v0.7.3
+[0.7.2]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/v0.7.1...v0.7.2
+[0.7.1]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/v0.6.3...v0.7.0
 [0.6.3]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/v0.6.2...v0.6.3
 [0.6.2]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/v0.6.1...v0.6.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/) from v0.5.0 forward.
 
+## Unreleased
+### Fixed
+- Also watch SVGs in `src/` and rerun the Nunjucks renderer when they change (#58)
+
+## [0.7.5] - 2018-03-01
+### Changed
+- Changed font weights on embeddables to use LifeBlue's Gotham
+
+## [0.7.4] - 2018-02-26
+### Changed
+- Change Typography.com account to LifeBlue's
+
 ## [0.7.3] - 2017-12-27
 ### Fixed
 - Correctly prepends leading `0` in dates in meta.json
@@ -204,7 +216,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/) from v0.5.
 ### Added
 - Initial working versions of files.
 
-[Unreleased]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/338270b3637169712a31751f8e203e76baf2b09c...HEAD
+[Unreleased]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/6aab9f55ec148cbc269083b9326e9d36926881db...HEAD
+[0.7.5]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/fb56abcf7731d6284ed24bd4aa93bfabced809ad...6aab9f55ec148cbc269083b9326e9d36926881db
+[0.7.4]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/338270b3637169712a31751f8e203e76baf2b09c...fb56abcf7731d6284ed24bd4aa93bfabced809ad
 [0.7.3]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/0cd22e4af3f133720612f9aa322555a766af15b4...338270b3637169712a31751f8e203e76baf2b09c
 [0.7.2]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/faaf14fb6e120e84112129eb80efc212f40f6e65...0cd22e4af3f133720612f9aa322555a766af15b4
 [0.7.1]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/v0.7.0...faaf14fb6e120e84112129eb80efc212f40f6e65

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/) from v0.5.
 ## Unreleased
 ### Added
 - Invalidate Cloudfront for published objects during publish (#59)
+- Add cache headers to images and videos (#59)
 
 ### Fixed
 - Also watch SVGs in `src/` and rerun the Nunjucks renderer when they change (#58)

--- a/generators/embeddable-graphic/templates/gulp/tasks/aws.js
+++ b/generators/embeddable-graphic/templates/gulp/tasks/aws.js
@@ -3,10 +3,18 @@
 const confirm = require('gulp-confirm');
 const rename = require('gulp-rename');
 const awspublish = require('gulp-awspublish');
+const cloudfront = require('gulp-cloudfront-invalidate-aws-publish');
 const gulp = require('gulp');
 
 const awsJson = require('../../aws.json');
 const meta = require('../../meta.json');
+
+const cfSettings = {
+  distribution: 'E3QK9W6AW5LAVH',
+  accessKeyId: awsJson.accessKeyId,
+  secretAccessKey: awsJson.secretAccessKey,
+  wait: false,
+};
 
 
 module.exports = () => {
@@ -23,5 +31,6 @@ module.exports = () => {
     }))
     .pipe(publisher.publish({}, { force: false }))
     .pipe(publisher.cache())
+    .pipe(cloudfront(cfSettings))
     .pipe(awspublish.reporter());
 };

--- a/generators/embeddable-graphic/templates/gulp/tasks/aws.js
+++ b/generators/embeddable-graphic/templates/gulp/tasks/aws.js
@@ -17,22 +17,24 @@ const cfSettings = {
   wait: false,
 };
 
+const oneDayInMS = 60 * 60 * 24;
+
 const routes = {
   routes: {
     // Cache video and audio for 1 week on user's computer, one month in CloudFront
     '^.*\\.(aif|iff|m3u|m4a|mid|mp3|mpa|ra|wav|wma|3g2|3gp|asf|asx|avi|flv|mov|mp4|mpg|rm|swf|vob|wmv)': {
-      cacheTime: 86400 * 7,
-      sharedCacheTime: 86400 * 30,
+      cacheTime: oneDayInMS * 7,
+      sharedCacheTime: oneDayInMS * 30,
     },
     // Cache images 2 days on user's computer, one month in CloudFront
     '^.*\\.(jpg|jpeg|svg|bmp|png|tiff|gif)': {
-      cacheTime: 60 * 60 * 24 * 2,
-      sharedCacheTime: 86400 * 30,
+      cacheTime: oneDayInMS * 2,
+      sharedCacheTime: oneDayInMS * 30,
     },
     // Cache images 5 minutes on user's computer, one month in CloudFront
     '^.*\\.(html|js|css)': {
       cacheTime: 60 * 5,
-      sharedCacheTime: 86400,
+      sharedCacheTime: oneDayInMS,
     },
   },
 };
@@ -43,11 +45,14 @@ module.exports = () => {
 
   return gulp.src('./dist/**/*')
     .pipe(confirm({
-      question: `You're about to publish this project to AWS under directory ${awsDirectory}. Are you sure you want to do this?`,
-      input: '_key:y'
+      question: `You're about to publish this project to AWS under directory ${
+        awsDirectory
+      }. Are you sure you want to do this?`,
+      input: '_key:y',
     }))
     .pipe(rename((path) => {
-      path.dirname = awsDirectory + path.dirname.replace('.\\','');
+      // eslint-disable-next-line no-param-reassign
+      path.dirname = awsDirectory + path.dirname.replace('.\\', '');
     }))
     .pipe(awspublishRouter(routes))
     .pipe(publisher.publish({}, { force: false }))

--- a/generators/embeddable-graphic/templates/gulp/tasks/aws.js
+++ b/generators/embeddable-graphic/templates/gulp/tasks/aws.js
@@ -3,6 +3,7 @@
 const confirm = require('gulp-confirm');
 const rename = require('gulp-rename');
 const awspublish = require('gulp-awspublish');
+const awspublishRouter = require("gulp-awspublish-router");
 const cloudfront = require('gulp-cloudfront-invalidate-aws-publish');
 const gulp = require('gulp');
 
@@ -16,6 +17,25 @@ const cfSettings = {
   wait: false,
 };
 
+const routes = {
+  routes: {
+    // Cache video and audio for 1 week on user's computer, one month in CloudFront
+    '^.*\\.(aif|iff|m3u|m4a|mid|mp3|mpa|ra|wav|wma|3g2|3gp|asf|asx|avi|flv|mov|mp4|mpg|rm|swf|vob|wmv)': {
+      cacheTime: 86400 * 7,
+      sharedCacheTime: 86400 * 30,
+    },
+    // Cache images 2 days on user's computer, one month in CloudFront
+    '^.*\\.(jpg|jpeg|svg|bmp|png|tiff|gif)': {
+      cacheTime: 60 * 60 * 24 * 2,
+      sharedCacheTime: 86400 * 30,
+    },
+    // Cache images 5 minutes on user's computer, one month in CloudFront
+    '^.*\\.(html|js|css)': {
+      cacheTime: 60 * 5,
+      sharedCacheTime: 86400,
+    },
+  },
+};
 
 module.exports = () => {
   const publisher = awspublish.create(awsJson);
@@ -29,6 +49,7 @@ module.exports = () => {
     .pipe(rename((path) => {
       path.dirname = awsDirectory + path.dirname.replace('.\\','');
     }))
+    .pipe(awspublishRouter(routes))
     .pipe(publisher.publish({}, { force: false }))
     .pipe(publisher.cache())
     .pipe(cloudfront(cfSettings))

--- a/generators/embeddable-graphic/templates/gulp/tasks/server.js
+++ b/generators/embeddable-graphic/templates/gulp/tasks/server.js
@@ -15,5 +15,5 @@ module.exports = () => {
 
   gulp.watch(['./src/sass/*.scss'], ['sass']);
   gulp.watch(['./src/data/**/*'], ['data']);
-  gulp.watch(['./src/*.{html,svg}'], ['html']);
+  gulp.watch(['./src/*.html'], ['html']);
 };

--- a/generators/embeddable-graphic/templates/gulp/tasks/server.js
+++ b/generators/embeddable-graphic/templates/gulp/tasks/server.js
@@ -15,5 +15,5 @@ module.exports = () => {
 
   gulp.watch(['./src/sass/*.scss'], ['sass']);
   gulp.watch(['./src/data/**/*'], ['data']);
-  gulp.watch(['./src/*.html'], ['html']);
+  gulp.watch(['./src/*.{html,svg}'], ['html']);
 };

--- a/generators/embeddable-graphic/templates/package.json
+++ b/generators/embeddable-graphic/templates/package.json
@@ -19,6 +19,7 @@
     "event-stream": "^3.3.4",
     "gulp": "^3.9.1",
     "gulp-awspublish": "^3.3.0",
+    "gulp-awspublish-router": "^0.1.5",
     "gulp-cloudfront-invalidate-aws-publish": "^0.2.0",
     "gulp-confirm": "^1.0.4",
     "gulp-postcss": "^7.0.0",

--- a/generators/embeddable-graphic/templates/package.json
+++ b/generators/embeddable-graphic/templates/package.json
@@ -19,6 +19,7 @@
     "event-stream": "^3.3.4",
     "gulp": "^3.9.1",
     "gulp-awspublish": "^3.3.0",
+    "gulp-cloudfront-invalidate-aws-publish": "^0.2.0",
     "gulp-confirm": "^1.0.4",
     "gulp-postcss": "^7.0.0",
     "gulp-rename": "^1.2.2",

--- a/generators/page/templates/gulp/tasks/aws.js
+++ b/generators/page/templates/gulp/tasks/aws.js
@@ -5,6 +5,7 @@
 /* eslint-enable strict */
 
 const awspublish = require('gulp-awspublish');
+const cloudfront = require('gulp-cloudfront-invalidate-aws-publish');
 const confirm = require('gulp-confirm');
 const deline = require('deline');
 const gulp = require('gulp');
@@ -25,6 +26,12 @@ const year = meta.publishYear;
 
 const awsDirectory = `${year}/${appName}/`;
 
+const cfSettings = {
+  distribution: 'E3QK9W6AW5LAVH',
+  accessKeyId: awsJson.accessKeyId,
+  secretAccessKey: awsJson.secretAccessKey,
+  wait: false,
+};
 
 module.exports = () =>
     gulp.src('./dist/**/*')
@@ -43,6 +50,7 @@ module.exports = () =>
         .pipe(publisher.publish({}, { force: false }))
         .pipe(publisher.cache())
         .pipe(awspublish.reporter())
+        .pipe(cloudfront(cfSettings))
         .on(
           'end',
           gutil.log.bind(

--- a/generators/page/templates/gulp/tasks/aws.js
+++ b/generators/page/templates/gulp/tasks/aws.js
@@ -33,22 +33,24 @@ const cfSettings = {
   wait: false,
 };
 
+const oneDayInMS = 60 * 60 * 24;
+
 const routes = {
   routes: {
     // Cache video and audio for 1 week on user's computer, one month in CloudFront
     '^.*\\.(aif|iff|m3u|m4a|mid|mp3|mpa|ra|wav|wma|3g2|3gp|asf|asx|avi|flv|mov|mp4|mpg|rm|swf|vob|wmv)': {
-      cacheTime: 86400 * 7,
-      sharedCacheTime: 86400 * 30,
+      cacheTime: oneDayInMS * 7,
+      sharedCacheTime: oneDayInMS * 30,
     },
     // Cache images 2 days on user's computer, one month in CloudFront
     '^.*\\.(jpg|jpeg|svg|bmp|png|tiff|gif)': {
-      cacheTime: 60 * 60 * 24 * 2,
-      sharedCacheTime: 86400 * 30,
+      cacheTime: oneDayInMS * 2,
+      sharedCacheTime: oneDayInMS * 30,
     },
     // Cache images 5 minutes on user's computer, one month in CloudFront
     '^.*\\.(html|js|css)': {
       cacheTime: 60 * 5,
-      sharedCacheTime: 86400,
+      sharedCacheTime: oneDayInMS,
     },
   },
 };

--- a/generators/page/templates/gulp/tasks/server.js
+++ b/generators/page/templates/gulp/tasks/server.js
@@ -24,7 +24,7 @@ module.exports = () => {
 
   watch('./src/scss/**/*.scss', () => { runSequence('scss'); });
 
-  watch('./src/templates/**/*.html', () => { runSequence('templates'); });
+  watch('./src/templates/**/*.{html,svg}', () => { runSequence('templates'); });
 
   watch(
     [

--- a/generators/page/templates/package.json
+++ b/generators/page/templates/package.json
@@ -17,6 +17,7 @@
     "gulp-awspublish": "^3.0.1",
     "gulp-batch": "^1.0.5",
     "gulp-changed": "^2.0.0",
+    "gulp-cloudfront-invalidate-aws-publish": "^0.2.0",
     "gulp-confirm": "^1.0.4",
     "gulp-image-resize": "^0.12.0",
     "gulp-imagemin": "^3.1.1",

--- a/generators/page/templates/package.json
+++ b/generators/page/templates/package.json
@@ -15,6 +15,7 @@
     "event-stream": "^3.3.4",
     "gulp": "^3.9.0",
     "gulp-awspublish": "^3.0.1",
+    "gulp-awspublish-router": "^0.1.5",
     "gulp-batch": "^1.0.5",
     "gulp-changed": "^2.0.0",
     "gulp-cloudfront-invalidate-aws-publish": "^0.2.0",


### PR DESCRIPTION
This adds aggressive `maxage` and `s-maxage` headers for CloudFront and includes logic to purge newly-published files from CloudFront's cache using invalidations. It adds two new `gulp-*` modules - one to handle the CloudFront invalidations and another to handle conditionally setting cache headers based on file extensions.