### PR TITLE
Publish to .test bucket, rather than public interactives bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/) from v0.5.
 - Invalidate Cloudfront for published objects during publish (#59)
 - Add cache headers to images and videos (#59)
 
+### Changed
+- Publishes test content as private to new password-protected test bucket
+
 ### Fixed
 - Also watch SVGs in `src/` and rerun the Nunjucks renderer when they change (#58)
 

--- a/generators/page/templates/gulp/tasks/aws-test.js
+++ b/generators/page/templates/gulp/tasks/aws-test.js
@@ -24,7 +24,11 @@ const awsDirectory = `test/${appName}/`;
 
 
 module.exports = () => {
-  const publisher = awspublish.create(awsJson);
+  const publisher = awspublish.create(Object.assign(awsJson, {
+    params: {
+      Bucket: 'interactives.dallasnews.com.test'
+    }
+  }));
 
   return gulp.src('./dist/**/*')
       .pipe(confirm({
@@ -37,7 +41,7 @@ module.exports = () => {
         // eslint-disable-next-line no-param-reassign
         filePath.dirname = awsDirectory + filePath.dirname.replace('.\\', '');
       }))
-      .pipe(publisher.publish({}, { force: false }))
+      .pipe(publisher.publish({}, { force: false, noAcl: true }))
       .pipe(publisher.cache())
       .pipe(awspublish.reporter());
 };

--- a/generators/page/templates/gulp/tasks/clear-test.js
+++ b/generators/page/templates/gulp/tasks/clear-test.js
@@ -26,7 +26,7 @@ module.exports = () => {
   const s3 = new aws.S3();
 
   let params = {
-    Bucket: awsJson.params.Bucket,
+    Bucket: 'interactives.dallasnews.com.test',
     // Do not change this!
     Prefix: `test/${appName}`,
   };


### PR DESCRIPTION
This implements the generator side of the changes we did last week to password protect `interactives.dallasnews.com/test/*`.

I think once this is in we should consider rolling a new version.

cc @allanjamesvestal @jdhancock88 