### PR TITLE
Fix for errors while running "publish"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/) from v0.5.0 forward.
 
 ## [Unreleased]
+Nothing ... yet
+
+## [0.8.3] - 2018-08-21
 ### Fixed
 - Fixed an error where files that didn't match a ["route"](https://github.com/DallasMorningNews/generator-dmninteractives/blob/b84e0bbe16f70f7ef469fd1a010df26f9759aad6/generators/page/templates/gulp/tasks/aws.js#L38-L56) pattern in our AWS publishing stream would throw an error
 
@@ -256,7 +259,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/) from v0.5.
 ### Added
 - Initial working versions of files.
 
-[Unreleased]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/v0.8.2...HEAD
+[Unreleased]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/v0.8.3...HEAD
+[0.8.3]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/v0.8.1...v0.8.3
 [0.8.2]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/v0.7.7...v0.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/) from v0.5.0 forward.
 
+## [Unreleased]
+### Fixed
+- Fixed an error where files that didn't match a ["route"](https://github.com/DallasMorningNews/generator-dmninteractives/blob/b84e0bbe16f70f7ef469fd1a010df26f9759aad6/generators/page/templates/gulp/tasks/aws.js#L38-L56) pattern in our AWS publishing stream would throw an error
+
 ## [0.8.2] - 2018-08-2
 ### Changed
 - Only include 300 and 700 weight Monsterrat

--- a/generators/embeddable-graphic/templates/gulp/tasks/aws.js
+++ b/generators/embeddable-graphic/templates/gulp/tasks/aws.js
@@ -36,6 +36,8 @@ const routes = {
       cacheTime: 60 * 5,
       sharedCacheTime: oneDayInMS,
     },
+    // Catch everything else in an empty route, or we'll get errors
+    '.*': {},
   },
 };
 

--- a/generators/page/templates/gulp/tasks/aws.js
+++ b/generators/page/templates/gulp/tasks/aws.js
@@ -52,6 +52,8 @@ const routes = {
       cacheTime: 60 * 5,
       sharedCacheTime: oneDayInMS,
     },
+    // Catch everything else in an empty route, or we'll get errors
+    '.*': {},
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-dmninteractives",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Yeoman generator for interactive pages at The Dallas Morning News",
   "license": "MIT",
   "main": "app/index.js",


### PR DESCRIPTION
The new `gulp-awspublish-router` module we use to set certain headers based on file types apparently fails when a file doesn't match one of the defined route patterns. This adds a generic one that catches everything for which we don't have specific settings.