### PR TITLE
Meta share image fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Nothing ... yet
 ## [0.8.4] - 2018-10-09
 ### Fixed
 - Include `/images/` in URL for share image in meta.json
-- Also invalidate root paths (`project/` and `project/index.html`) in Cloudfront
+- Also invalidate root paths (`year/slug/`) in Cloudfront [#67](https://github.com/DallasMorningNews/generator-dmninteractives/issues/67)
 
 ## [0.8.3] - 2018-08-21
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Nothing ... yet
 ## [0.8.4] - 2018-10-09
 ### Fixed
 - Include `/images/` in URL for share image in meta.json
+- Also invalidate root paths (`project/` and `project/index.html`) in Cloudfront
 
 ## [0.8.3] - 2018-08-21
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/) from v0.5.
 ## [Unreleased]
 Nothing ... yet
 
+## [0.8.4] - 2018-10-09
+### Fixed
+- Include `/images/` in URL for share image in meta.json
+
 ## [0.8.3] - 2018-08-21
 ### Fixed
 - Fixed an error where files that didn't match a ["route"](https://github.com/DallasMorningNews/generator-dmninteractives/blob/b84e0bbe16f70f7ef469fd1a010df26f9759aad6/generators/page/templates/gulp/tasks/aws.js#L38-L56) pattern in our AWS publishing stream would throw an error
@@ -259,7 +263,8 @@ Nothing ... yet
 ### Added
 - Initial working versions of files.
 
-[Unreleased]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/v0.8.3...HEAD
+[Unreleased]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/v0.8.4...HEAD
+[0.8.4]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/v0.8.3...v0.8.4
 [0.8.3]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/v0.8.2...v0.8.3
 [0.8.2]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/DallasMorningNews/generator-dmninteractives/compare/v0.8.0...v0.8.1

--- a/generators/embeddable-graphic/templates/gulp/tasks/aws.js
+++ b/generators/embeddable-graphic/templates/gulp/tasks/aws.js
@@ -15,6 +15,7 @@ const cfSettings = {
   accessKeyId: awsJson.accessKeyId,
   secretAccessKey: awsJson.secretAccessKey,
   wait: false,
+  indexRootPath: true,
 };
 
 const oneDayInMS = 60 * 60 * 24;

--- a/generators/embeddable-graphic/templates/gulp/tasks/aws.js
+++ b/generators/embeddable-graphic/templates/gulp/tasks/aws.js
@@ -58,7 +58,7 @@ module.exports = () => {
     }))
     .pipe(awspublishRouter(routes))
     .pipe(publisher.publish({}, { force: false }))
-    .pipe(publisher.cache())
     .pipe(cloudfront(cfSettings))
+    .pipe(publisher.cache())
     .pipe(awspublish.reporter());
 };

--- a/generators/page/index.js
+++ b/generators/page/index.js
@@ -218,7 +218,7 @@ module.exports = yeoman.Base.extend({
           timestamp.getFullYear()
         }/${
           this.appName.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase()
-        }/${
+        }/images/${
           this.shareImage
         }`,
         imgWidth: '<Width - w/out "px">',

--- a/generators/page/templates/gulp/tasks/aws.js
+++ b/generators/page/templates/gulp/tasks/aws.js
@@ -31,6 +31,7 @@ const cfSettings = {
   accessKeyId: awsJson.accessKeyId,
   secretAccessKey: awsJson.secretAccessKey,
   wait: false,
+  indexRootPath: true,
 };
 
 const oneDayInMS = 60 * 60 * 24;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-dmninteractives",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Yeoman generator for interactive pages at The Dallas Morning News",
   "license": "MIT",
   "main": "app/index.js",


### PR DESCRIPTION
This rolls in your fix, @jdhancock88, and closes #67.

#67 turned out to be a more widespread issue than the embeds. It turned out both embeds and pages were being run through the invalidator but the root paths for projects weren't being included in either case. That's now fixed.